### PR TITLE
fix: Improve getParam usage with custom error

### DIFF
--- a/.changeset/wild-meals-eat.md
+++ b/.changeset/wild-meals-eat.md
@@ -1,0 +1,5 @@
+---
+"gatsby-source-tmdb": patch
+---
+
+fix: Improve getParam usage with custom error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "package/**"
 jobs:
   release:
     name: Release
@@ -14,6 +12,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-12.x-modules-${{ hashFiles('**/yarn.lock') }}
       - name: Setup Node.js 12.x
         uses: actions/setup-node@v1
         with:

--- a/package/src/__tests__/api-utils.ts
+++ b/package/src/__tests__/api-utils.ts
@@ -33,6 +33,7 @@ describe(`api-utils`, () => {
   })
   it(`getParam should capture param`, () => {
     expect(getParam(`/tv/:tv_id`)).toBe(`tv_id`)
+    expect(getParam(`/tv/1234`)).toBe(undefined)
   })
   it(`defaultOptions works correctly`, () => {
     expect(defaultOptions({ apiKey: `foo`, sessionID: `bar`, plugins: [] })).toMatchInlineSnapshot(`
@@ -79,6 +80,9 @@ describe(`api-utils`, () => {
   it(`generateTypeName works correctly`, () => {
     expect(generateTypeName({ url: `account/:account_id/favorite/movies` }, `Tmdb`)).toBe(`TmdbAccountFavoriteMovies`)
     expect(generateTypeName({ url: `tv/:tv_id`, context: { tv_id: `1234` } }, `Tmdb`)).toBe(`TmdbTv1234`)
+    expect(generateTypeName({ url: `tv/:tv_id`, context: { tv_id: `1234` }, typeName: `CustomName` }, `Tmdb`)).toBe(
+      `TmdbCustomName`
+    )
     expect(generateTypeName({ url: `account/:account_id/favorite/movies`, typeName: `CustomName` }, `Tmdb`)).toBe(
       `TmdbCustomName`
     )

--- a/package/src/api-utils.ts
+++ b/package/src/api-utils.ts
@@ -33,7 +33,7 @@ const getParamRegex = /:(.*)/
  * @param url
  * @return Parameter without colon
  */
-export const getParam = (url: string): string => url.match(getParamRegex)[1]
+export const getParam = (url: string): string => url.match(getParamRegex)?.[1]
 
 /**
  * Combine the user plugin options with the default options

--- a/package/src/constants.ts
+++ b/package/src/constants.ts
@@ -3,6 +3,7 @@ export const ERROR_CODES = {
   initialSourcing: `30000`,
   individualSourcing: `30001`,
   extensionSourcing: `30002`,
+  getParamUndefined: `30003`,
 }
 export const IMAGE_TYPES = [`backdrop`, `logo`, `poster`, `profile`, `still`] as const
 export const IMAGE_TYPE_NAMES = [`BackdropPath`, `LogoPath`, `PosterPath`, `ProfilePath`, `StillPath`] as const

--- a/package/src/node-builder.ts
+++ b/package/src/node-builder.ts
@@ -126,6 +126,17 @@ export const nodeBuilder = async ({
     if (endpoint.extension) {
       try {
         const param = getParam(endpoint.extension.url)
+
+        if (!param) {
+          gatsbyApi.reporter.panicOnBuild({
+            id: ERROR_CODES.getParamUndefined,
+            context: {
+              sourceMessage: `Couldn't find a parameter for ${endpoint.extension.url} - make sure it uses the format :your_parameter`,
+            },
+          })
+          itemTimer.end()
+        }
+
         const detailedItems = items.map((item) =>
           fetchData({ url: endpoint.extension.url, context: { [param]: item.id } })
         )


### PR DESCRIPTION
When passing in an invalid `extension.url` of an `Endpoint` (so that `getParam` doesn't find anything) throw a customized error