### PR TITLE
fix(gatsby-source-tmdb): LICENSE, better plugin options, README

### DIFF
--- a/.changeset/old-goats-jump.md
+++ b/.changeset/old-goats-jump.md
@@ -1,0 +1,8 @@
+---
+"gatsby-source-tmdb": patch
+---
+
+- Add a LICENSE
+- Add regex to plugin options so that `url` won't have a leading slash
+- Fix README links + add link to migration guide
+- Update dependencies

--- a/package/CHANGELOG.md
+++ b/package/CHANGELOG.md
@@ -11,3 +11,35 @@
 ### Patch Changes
 
 - Update description of the npm package and edit npmignore to not commit tsconfig to source code. Also updates links to documentation.
+
+## 2.0.0
+
+### Major Changes
+
+**Description:**
+
+Hello!
+
+With https://github.com/LekoArts/gatsby-source-tmdb/pull/9 merged a new `v2` of `gatsby-source-tmdb` is out.
+
+**Key highlights** of this release:
+
+- The plugin doesn't download all images upfront anymore, only on demand when you use `localFile`
+- Easier handling of endpoints with the new `endpoints` option
+- Query any endpoint you can think of and extend requests with the new `extension` option
+- You can use multiple instances of the plugin with `typePrefix`
+- Custom plugin errors for easier debugging
+- Uses `pluginOptionSchema` to validate plugin options
+- Better logging & progress bars
+
+You can find all plugin options here: https://github.com/LekoArts/gatsby-source-tmdb/tree/main/package#options
+
+**Breaking Changes:**
+
+- The `modules` option was replaced with `endpoints`
+- The image nodes (e.g. `backdrop_path`) have another shape now with `localFile` in them
+- The `reqPerTenSeconds` option was removed
+- The `poster` & `backdrop` option was removed
+
+You can read a migration guide here: https://github.com/LekoArts/gatsby-source-tmdb/blob/main/MIGRATING.md
+

--- a/package/LICENSE
+++ b/package/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 LekoArts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package/README.md
+++ b/package/README.md
@@ -2,7 +2,9 @@
 
 Source from [The Movie Database (TMDb)](https://www.themoviedb.org/) API (v3) in Gatsby. You can leverage any endpoint from the [official documentation](https://developers.themoviedb.org/3/getting-started/introduction) and pull the data directly into Gatsby's GraphQL data layer. Customize the plugin to your needs by providing customized endpoints -- read more about that in the [advanced configuration](#advanced-configuration) section.
 
-You can see a **live preview** at [tmdb.lekoarts.de](https://tmdb.lekoarts.de) ([Source Code](https://github.com/LekoArts/gatsby-source-tmdb/tree/main/example))
+You can see a **live preview** at [tmdb.lekoarts.de](https://tmdb.lekoarts.de) ([Source Code](https://github.com/LekoArts/gatsby-source-tmdb/tree/main/example)).
+
+Create your own website with [gatsby-starter-tmdb](https://github.com/LekoArts/gatsby-starter-tmdb).
 
 ## Install
 
@@ -41,7 +43,7 @@ module.exports = {
 }
 ```
 
-The plugin is **not** requesting all available endpoints by default but only a [selected list](https://github.com/LekoArts/gatsby-source-tmdb/blob/main/package/src/endpoint.ts) of endpoints. It always requests the `/account` & `/configuration` endpoint. Please see the documentation below if you want to change the endpoints.
+The plugin is **not** requesting all available endpoints by default but only a [selected list](https://github.com/LekoArts/gatsby-source-tmdb/blob/main/package/src/endpoints.ts) of endpoints. It always requests the `/account` & `/configuration` endpoint. Please see the documentation below if you want to change the endpoints.
 
 ## Options
 
@@ -98,7 +100,7 @@ interface Endpoint {
 }
 ```
 
-This option allows you to configure the endpoints that the plugin is requesting from the TMDb API. The plugin defines some [sensible defaults](https://github.com/LekoArts/gatsby-source-tmdb/blob/main/package/src/endpoint.ts).
+This option allows you to configure the endpoints that the plugin is requesting from the TMDb API. The plugin defines some [sensible defaults](https://github.com/LekoArts/gatsby-source-tmdb/blob/main/package/src/endpoints.ts).
 
 The plugin uses [`got`](https://github.com/sindresorhus/got) under the hood, so some options directly come from its API design. Here are the options in detail:
 
@@ -219,3 +221,7 @@ module.exports = {
   ]
 }
 ```
+
+## Migration
+
+You want to migrate to a new major version? You can read all migration guides here: https://github.com/LekoArts/gatsby-source-tmdb/blob/main/MIGRATING.md

--- a/package/package.json
+++ b/package/package.json
@@ -20,14 +20,14 @@
   "private": false,
   "dependencies": {
     "gatsby-node-helpers": "^1.2.1",
-    "gatsby-source-filesystem": "^3.2.0",
+    "gatsby-source-filesystem": "^3.4.0",
     "got": "^11.8.2"
   },
   "devDependencies": {
     "@types/got": "^9.6.11",
     "cross-env": "^7.0.3",
-    "gatsby": "^3.2.1",
-    "gatsby-plugin-utils": "^1.2.0"
+    "gatsby": "^3.4.0",
+    "gatsby-plugin-utils": "^1.4.0"
   },
   "keywords": [
     "gatsby",
@@ -38,7 +38,7 @@
     "themoviedatabase"
   ],
   "peerDependencies": {
-    "gatsby": ">=3.0.0"
+    "gatsby": "^3.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/package/src/__tests__/plugin-options-schema.ts
+++ b/package/src/__tests__/plugin-options-schema.ts
@@ -12,10 +12,16 @@ describe(`pluginOptionsSchema`, () => {
       endpoints: [
         {
           countLimit: `foobar`,
-          no_url: `foobar`,
+          url: `/with-leading-slash`,
           searchParams: {
             language: 123,
           },
+          extension: {
+            url: `/with-leading-slash`,
+          },
+        },
+        {
+          no_url: `foobar`,
         },
       ],
       typePrefix: `invalid 2`,
@@ -30,11 +36,13 @@ describe(`pluginOptionsSchema`, () => {
       `"language" with value "English" fails to match the ISO 639-1 pattern`,
       `"region" with value "New York" fails to match the ISO 3166-1 pattern`,
       `"timezone" with value "ZW" fails to match the Region/City pattern`,
-      `"endpoints[0].url" is required`,
+      `"endpoints[0].url" with value "/with-leading-slash" fails to match the No leading slash pattern`,
       `"endpoints[0].searchParams.language" must be a string`,
       `"endpoints[0].countLimit" must be a number`,
-      `"endpoints[0].no_url" is not allowed`,
-      `"typePrefix" with value "invalid 2" fails to match the required pattern: /^[a-zA-Z_][A-Za-z0-9_]*$/`,
+      `"endpoints[0].extension.url" with value "/with-leading-slash" fails to match the No leading slash pattern`,
+      `"endpoints[1].url" is required`,
+      `"endpoints[1].no_url" is not allowed`,
+      `"typePrefix" with value "invalid 2" fails to match the Valid GraphQL typePrefix pattern`,
     ])
   })
   it(`should validate correct options`, async () => {
@@ -46,7 +54,7 @@ describe(`pluginOptionsSchema`, () => {
       timezone: `America/New_York`,
       endpoints: [
         {
-          url: `foobar`,
+          url: `account/:account_id/lists`,
           searchParams: {
             language: `de-DE`,
             foo: `bar`,
@@ -55,6 +63,9 @@ describe(`pluginOptionsSchema`, () => {
             foo: `bar`,
           },
           countLimit: 60,
+          extension: {
+            url: `movie/:movie_id`,
+          },
         },
       ],
       typePrefix: `Leko`,

--- a/package/src/plugin-options-schema.ts
+++ b/package/src/plugin-options-schema.ts
@@ -6,6 +6,8 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
   const EndpointKeys = Joi.object().keys({
     url: Joi.string()
       .required()
+      .lowercase()
+      .pattern(/^[^/].*$/, `No leading slash`)
       .description(
         `This is the endpoint that you want to get (without a leading slash). So e.g. account/:account_id/lists or movie/:movie_id. Replace the {some-key} with :some-key in the URL. The parameter also needs to be passed with the same name in context then.`
       ),
@@ -32,6 +34,8 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
     extension: Joi.object({
       url: Joi.string()
         .required()
+        .lowercase()
+        .pattern(/^[^/].*$/, `No leading slash`)
         .description(
           `The individual endpoint that should be used to get more information. The "id" from the previous/root endpoint will be used for the ":param" in this extension endpoint`
         ),
@@ -59,7 +63,7 @@ export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }):
       .default(`Europe/London`),
     endpoints: Joi.array().description(`Specify the TMDB endpoints that the plugin should access.`).items(EndpointKeys),
     typePrefix: Joi.string()
-      .pattern(/^[a-zA-Z_][A-Za-z0-9_]*$/)
+      .pattern(/^[a-zA-Z_][A-Za-z0-9_]*$/, `Valid GraphQL typePrefix`)
       .description(
         `Specify the prefix for all created nodes, e.g. allTmdbAccount. It must follow this spec: https://spec.graphql.org/draft/#sec-Names`
       )


### PR DESCRIPTION
- Add a LICENSE
- Add regex to plugin options so that `url` won't have a leading slash
- Fix README links + add link to migration guide
- Update dependencies